### PR TITLE
Fix memory leak for audio

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1,4 +1,5 @@
 #include "video.hpp"
+#include "godot_cpp/core/memory.hpp"
 
 Dictionary Video::get_video_file_meta(String a_file_path) {
 	AVFormatContext *l_av_format_ctx = NULL;
@@ -192,9 +193,8 @@ int Video::open_video(String a_path, bool a_load_audio) {
 }
 
 void Video::close_video() {
+	memdelete(audio);
 	is_open = false;
-	if (!audio.is_null())
-		audio.unref();
 
 	if (av_format_ctx)
 		avformat_close_input(&av_format_ctx);

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -47,7 +47,7 @@ private:
 	long start_time_video = 0, frame_timestamp = 0, current_pts = 0;
 	double average_frame_duration = 0, stream_time_base_video = 0;
 
-	Ref<AudioStreamWAV> audio = memnew(AudioStreamWAV);
+	AudioStreamWAV* audio = memnew(AudioStreamWAV);
 
 	bool is_open = false, variable_framerate = false;
 	int64_t video_duration = 0;


### PR DESCRIPTION
Fixes #7

Was a simple fix. Should remember to not use Ref<> for variable types and just use * as normally would be used in C++. A messup because I was not familiar with the Godot side of things.