### PR TITLE
remove intermediate copy when making textures to send to shader

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -243,9 +243,9 @@ int Video::open(String a_path, bool a_load_audio) {
 			av_hw_frame = av_frame_alloc();
 			sws_scale_frame(sws_ctx, av_hw_frame, av_frame);
 
-			y_data = Image::create_empty(av_frame->linesize[0] , resolution.y, false, Image::FORMAT_R8);
-			u_data = Image::create_empty(av_frame->linesize[1] , resolution.y/2, false, Image::FORMAT_R8);
-			v_data = Image::create_empty(av_frame->linesize[2] , resolution.y/2, false, Image::FORMAT_R8);
+			y_data = Image::create_empty(av_hw_frame->linesize[0] , resolution.y, false, Image::FORMAT_R8);
+			u_data = Image::create_empty(av_hw_frame->linesize[1] , resolution.y/2, false, Image::FORMAT_R8);
+			v_data = Image::create_empty(av_hw_frame->linesize[2] , resolution.y/2, false, Image::FORMAT_R8);
 			padding = av_hw_frame->linesize[0] - resolution.x;
 
 			av_frame_unref(av_hw_frame);
@@ -254,8 +254,8 @@ int Video::open(String a_path, bool a_load_audio) {
 		if (av_hwframe_transfer_data(av_hw_frame, av_frame, 0) < 0)
 			_printerr_debug("Error transferring the frame to system memory!");
 
-		y_data = Image::create_empty(av_frame->linesize[0] , resolution.y, false, Image::FORMAT_R8);
-		u_data = Image::create_empty(av_frame->linesize[1]/2 , resolution.y/2, false, Image::FORMAT_RG8);
+		y_data = Image::create_empty(av_hw_frame->linesize[0] , resolution.y, false, Image::FORMAT_R8);
+		u_data = Image::create_empty(av_hw_frame->linesize[1]/2 , resolution.y/2, false, Image::FORMAT_RG8);
 		padding = av_hw_frame->linesize[0] - resolution.x;
 		av_frame_unref(av_hw_frame);
 	} 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -228,9 +228,9 @@ int Video::open(String a_path, bool a_load_audio) {
 	// Preparing the data array's
 	if (!hw_decoding) {
 		if (av_frame->format == AV_PIX_FMT_YUV420P) {
-			y_data.resize(av_frame->linesize[0] * resolution.y);
-			u_data.resize(av_frame->linesize[1] * (resolution.y / 2));
-			v_data.resize(av_frame->linesize[2] * (resolution.y / 2));
+			y_data = Image::create_empty(av_frame->linesize[0] , resolution.y, false, Image::FORMAT_R8);
+			u_data = Image::create_empty(av_frame->linesize[1] , resolution.y/2, false, Image::FORMAT_R8);
+			v_data = Image::create_empty(av_frame->linesize[2] , resolution.y/2, false, Image::FORMAT_R8);
 			padding = av_frame->linesize[0] - resolution.x;
 		} else {
 			using_sws = true;
@@ -243,9 +243,9 @@ int Video::open(String a_path, bool a_load_audio) {
 			av_hw_frame = av_frame_alloc();
 			sws_scale_frame(sws_ctx, av_hw_frame, av_frame);
 
-			y_data.resize(av_hw_frame->linesize[0] * resolution.y);
-			u_data.resize(av_hw_frame->linesize[1] * (resolution.y / 2));
-			v_data.resize(av_hw_frame->linesize[2] * (resolution.y / 2));
+			y_data = Image::create_empty(av_frame->linesize[0] , resolution.y, false, Image::FORMAT_R8);
+			u_data = Image::create_empty(av_frame->linesize[1] , resolution.y/2, false, Image::FORMAT_R8);
+			v_data = Image::create_empty(av_frame->linesize[2] , resolution.y/2, false, Image::FORMAT_R8);
 			padding = av_hw_frame->linesize[0] - resolution.x;
 
 			av_frame_unref(av_hw_frame);
@@ -254,8 +254,8 @@ int Video::open(String a_path, bool a_load_audio) {
 		if (av_hwframe_transfer_data(av_hw_frame, av_frame, 0) < 0)
 			_printerr_debug("Error transferring the frame to system memory!");
 
-		y_data.resize(av_hw_frame->linesize[0] * resolution.y);
-		u_data.resize((av_hw_frame->linesize[1] / 2) * (resolution.y / 2) * 2);
+		y_data = Image::create_empty(av_frame->linesize[0] , resolution.y, false, Image::FORMAT_R8);
+		u_data = Image::create_empty(av_frame->linesize[1]/2 , resolution.y/2, false, Image::FORMAT_RG8);
 		padding = av_hw_frame->linesize[0] - resolution.x;
 		av_frame_unref(av_hw_frame);
 	} 
@@ -378,8 +378,8 @@ void Video::_copy_frame_data() {
 			return;
 		}
 
-		memcpy(y_data.ptrw(), av_hw_frame->data[0], y_data.size());
-		memcpy(u_data.ptrw(), av_hw_frame->data[1], u_data.size());
+		memcpy(y_data->ptrw(), av_hw_frame->data[0], y_data->get_size().x*y_data->get_size().y);
+		memcpy(u_data->ptrw(), av_hw_frame->data[1], u_data->get_size().x*u_data->get_size().y*2);
 
 		av_frame_unref(av_hw_frame);
 		return;
@@ -392,15 +392,15 @@ void Video::_copy_frame_data() {
 		if (using_sws) {
 			sws_scale_frame(sws_ctx, av_hw_frame, av_frame);
 
-			memcpy(y_data.ptrw(), av_hw_frame->data[0], y_data.size());
-			memcpy(u_data.ptrw(), av_hw_frame->data[1], u_data.size());
-			memcpy(v_data.ptrw(), av_hw_frame->data[2], v_data.size());
+			memcpy(y_data->ptrw(), av_hw_frame->data[0], y_data->get_size().x*y_data->get_size().y);
+			memcpy(u_data->ptrw(), av_hw_frame->data[1], u_data->get_size().x*u_data->get_size().y);
+			memcpy(v_data->ptrw(), av_hw_frame->data[2], v_data->get_size().x*v_data->get_size().y);
 
 			av_frame_unref(av_hw_frame);
 		} else {
-			memcpy(y_data.ptrw(), av_frame->data[0], y_data.size());
-			memcpy(u_data.ptrw(), av_frame->data[1], u_data.size());
-			memcpy(v_data.ptrw(), av_frame->data[2], v_data.size());
+			memcpy(y_data->ptrw(), av_frame->data[0], y_data->get_size().x*y_data->get_size().y);
+			memcpy(u_data->ptrw(), av_frame->data[1], u_data->get_size().x*u_data->get_size().y);
+			memcpy(v_data->ptrw(), av_frame->data[2], v_data->get_size().x*v_data->get_size().y);
 		}
 
 		return;

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -72,10 +72,9 @@ private:
 
 	AudioStreamWAV *audio = nullptr;
 
-	PackedByteArray byte_array;
-	PackedByteArray y_data;
-	PackedByteArray u_data;
-	PackedByteArray v_data;
+	Ref<Image> y_data;
+	Ref<Image> u_data;
+	Ref<Image> v_data;
 
 
 	// Private functions
@@ -138,9 +137,9 @@ public:
 
 	inline bool is_full_color_range() { return full_color_range; }
 
-	inline PackedByteArray get_y_data() { return y_data; }
-	inline PackedByteArray get_u_data() { return u_data; }
-	inline PackedByteArray get_v_data() { return v_data; }
+	inline Ref<Image> get_y_data() { return y_data; }
+	inline Ref<Image> get_u_data() { return u_data; }
+	inline Ref<Image> get_v_data() { return v_data; }
 
 
 protected:

--- a/test_room/addons/gde_gozen/video_playback.gd
+++ b/test_room/addons/gde_gozen/video_playback.gd
@@ -57,6 +57,10 @@ var _shader_material: ShaderMaterial = null
 var _thread: Thread = Thread.new()
 var _audio_pitch_effect: AudioEffectPitchShift = AudioEffectPitchShift.new()
 
+var y_texture: ImageTexture;
+var u_texture: ImageTexture;
+var v_texture: ImageTexture;
+
 
 #------------------------------------------------ TREE FUNCTIONS
 func _enter_tree() -> void:
@@ -303,26 +307,22 @@ func _set_current_frame(a_value: int) -> void:
 
 
 func _set_frame_image() -> void:
-	_shader_material.set_shader_parameter("y_data", _get_img_tex(
-		video.get_y_data(),
-		_resolution.x + _padding,
-		_resolution.y))
+	#first frame create texture
+	if(!y_texture):
+		y_texture = ImageTexture.create_from_image(video.get_y_data())
+		u_texture = ImageTexture.create_from_image(video.get_u_data())
+		if video.get_pixel_format().begins_with("yuv"):
+			v_texture = ImageTexture.create_from_image(video.get_v_data())
+	else: #just need to update texture, should be faster
+		y_texture.update(video.get_y_data())
+		u_texture.update(video.get_u_data())
+		if video.get_pixel_format().begins_with("yuv"):
+			v_texture.update(video.get_v_data())
 
+	_shader_material.set_shader_parameter("y_data", y_texture)
+	_shader_material.set_shader_parameter("u_data", u_texture)
 	if video.get_pixel_format().begins_with("yuv"):
-		_shader_material.set_shader_parameter("u_data", _get_img_tex(
-				video.get_u_data(),
-				_uv_resolution.x,
-				_uv_resolution.y))
-		_shader_material.set_shader_parameter("v_data", _get_img_tex(
-				video.get_v_data(),
-				_uv_resolution.x,
-				_uv_resolution.y))
-	else:
-		_shader_material.set_shader_parameter("u_data", _get_img_tex(
-				video.get_u_data(),
-				_uv_resolution.x,
-				_uv_resolution.y,
-				false))
+		_shader_material.set_shader_parameter("v_data", v_texture)
 
 
 func set_playback_speed(a_value: float) -> void:
@@ -385,4 +385,4 @@ func _print_video_debug() -> void:
 	print("Padding: ", _padding)
 	print("Rotation: ", _rotation)
 	print("Full color range: ", video.is_full_color_range())
-
+	


### PR DESCRIPTION
As discussed on discord before, removes some of the copying and avoids making a new texture each time the frame is updated.