### PR TITLE
Fix compile on macos

### DIFF
--- a/build.py
+++ b/build.py
@@ -160,7 +160,7 @@ def compile_ffmpeg_macos(a_arch):
     subprocess.run(['make', 'install'], cwd='./ffmpeg/')
 
     print('Copying lib files ...')
-    for l_file in glob.glob('bin/lib/*.dylib'):
+    for l_file in glob.glob('./ffmpeg/bin/lib/*.dylib'):
         shutil.copy2(l_file, l_path_debug)
         shutil.copy2(l_file, l_path_release)
 


### PR DESCRIPTION
the ffmpeg dylibs were not copied to the lib folder. 

I tested if with a debug build on an arm mac.

the upgrade to the godot submodule fixes the bug about the compile problems with `godot::Image`. has nothing to do with macos specifically i guess.