### PR TITLE
Adding res:// video support

### DIFF
--- a/src/ffmpeg.cpp
+++ b/src/ffmpeg.cpp
@@ -56,135 +56,29 @@ enum AVPixelFormat FFmpeg::get_hw_format(const enum AVPixelFormat *a_pix_fmt, en
 	return AV_PIX_FMT_NONE;
 }
 
+// For `res://` videos.
+int FFmpeg::read_buffer_packet(void *opaque, uint8_t *buffer, int buffer_size) {
+	BufferData * buffer_data = (BufferData *)opaque;
+	buffer_size = FFMIN(buffer_size, buffer_data->size - buffer_data->offset);
 
-AudioStreamWAV *FFmpeg::get_audio(AVFormatContext *a_format_ctx, AVStream *a_stream) {
-	AudioStreamWAV *l_audio = memnew(AudioStreamWAV);
+	if (buffer_size < 0)
+		return 0;
 
-	const AVCodec *l_codec_audio = avcodec_find_decoder(a_stream->codecpar->codec_id);
-	if (!l_codec_audio) {
-		UtilityFunctions::printerr("Couldn't find any codec decoder for audio!");
-		return l_audio;
+	memcpy(buffer, buffer_data->ptr + buffer_data->offset, buffer_size);
+	buffer_data->offset += buffer_size;
+	return buffer_size;
+}
+
+// For `res://` videos.
+int64_t FFmpeg::seek_buffer(void *opaque, int64_t offset, int where) {
+	BufferData *buffer_data = (BufferData *)opaque;
+
+	switch (where) {
+		case SEEK_SET: buffer_data->offset = offset; break;
+		case SEEK_CUR: buffer_data->offset += offset; break;
+		case SEEK_END: buffer_data->offset = buffer_data->size + offset; break;
+		case AVSEEK_SIZE: return buffer_data->size;
 	}
 
-	AVCodecContext *l_codec_ctx_audio = avcodec_alloc_context3(l_codec_audio);
-	if (l_codec_ctx_audio == NULL) {
-		UtilityFunctions::printerr("Couldn't allocate codec context for audio!");
-		return l_audio;
-	} else if (avcodec_parameters_to_context(l_codec_ctx_audio, a_stream->codecpar)) {
-		UtilityFunctions::printerr("Couldn't initialize audio codec context!");
-		return l_audio;
-	}
-
-	enable_multithreading(l_codec_ctx_audio, l_codec_audio);
-	l_codec_ctx_audio->request_sample_fmt = AV_SAMPLE_FMT_S16;
-
-	// Open codec - Audio
-	if (avcodec_open2(l_codec_ctx_audio, l_codec_audio, NULL)) {
-		UtilityFunctions::printerr("Couldn't open audio codec!");
-		return l_audio;
-	}
-
-	AVChannelLayout l_ch_layout;
-	struct SwrContext *l_swr_ctx = nullptr;
-	if (l_codec_ctx_audio->ch_layout.nb_channels <= 3) 
-		l_ch_layout = l_codec_ctx_audio->ch_layout;
-	else
-		l_ch_layout = AV_CHANNEL_LAYOUT_STEREO;
-
-	response = swr_alloc_set_opts2(
-		&l_swr_ctx, &l_ch_layout, AV_SAMPLE_FMT_S16,
-		l_codec_ctx_audio->sample_rate, &l_codec_ctx_audio->ch_layout,
-		l_codec_ctx_audio->sample_fmt, l_codec_ctx_audio->sample_rate, 0,
-		nullptr);
-
-	if (response < 0) {
-		print_av_error("Failed to obtain SWR context!", response);
-		avcodec_flush_buffers(l_codec_ctx_audio);
-		avcodec_free_context(&l_codec_ctx_audio);
-		return l_audio;
-	}
-
-	response = swr_init(l_swr_ctx);
-	if (response < 0) {
-		print_av_error("Couldn't initialize SWR!", response);
-		avcodec_flush_buffers(l_codec_ctx_audio);
-		avcodec_free_context(&l_codec_ctx_audio);
-		return l_audio;
-	}
-
-	AVFrame *l_frame = av_frame_alloc();
-	AVFrame *l_decoded_frame = av_frame_alloc();
-	AVPacket *l_packet = av_packet_alloc();
-	if (!l_frame || !l_decoded_frame || !l_packet) {
-		UtilityFunctions::printerr("Couldn't allocate frames or packet for audio!");
-		avcodec_flush_buffers(l_codec_ctx_audio);
-		avcodec_free_context(&l_codec_ctx_audio);
-		swr_free(&l_swr_ctx);
-		return l_audio;
-	}
-
-	int l_bytes_per_samples = av_get_bytes_per_sample(AV_SAMPLE_FMT_S16);
-	PackedByteArray l_audio_data = PackedByteArray();
-	bool l_stereo = l_codec_ctx_audio->ch_layout.nb_channels >= 2;
-	size_t l_audio_size = 0;
-
-	while (true) {
-		if (get_frame(a_format_ctx, l_codec_ctx_audio, a_stream->index, l_frame, l_packet))
-			break;
-
-		// Copy decoded data to new frame
-		l_decoded_frame->format = AV_SAMPLE_FMT_S16;
-		l_decoded_frame->ch_layout = l_ch_layout;
-		l_decoded_frame->sample_rate = l_frame->sample_rate;
-		l_decoded_frame->nb_samples = swr_get_out_samples(l_swr_ctx, l_frame->nb_samples);
-
-		if ((response = av_frame_get_buffer(l_decoded_frame, 0)) < 0) {
-			print_av_error("Couldn't create new frame for swr!", response);
-			av_frame_unref(l_frame);
-			av_frame_unref(l_decoded_frame);
-			break;
-		}
-
-		if ((response = swr_config_frame(l_swr_ctx, l_decoded_frame, l_frame)) < 0) {
-			print_av_error("Couldn't config the audio frame!", response);
-			av_frame_unref(l_frame);
-			av_frame_unref(l_decoded_frame);
-			break;
-		}
-
-		if ((response = swr_convert_frame(l_swr_ctx, l_decoded_frame, l_frame)) < 0) {
-			print_av_error("Couldn't convert the audio frame!", response);
-			av_frame_unref(l_frame);
-			av_frame_unref(l_decoded_frame);
-			break;
-		}
-
-		size_t l_byte_size = l_decoded_frame->nb_samples * l_bytes_per_samples;
-		if (l_codec_ctx_audio->ch_layout.nb_channels >= 2)
-			l_byte_size *= 2;
-
-		l_audio_data.resize(l_audio_size + l_byte_size);
-		memcpy(&(l_audio_data.ptrw()[l_audio_size]), l_decoded_frame->extended_data[0], l_byte_size);
-		l_audio_size += l_byte_size;
-
-		av_frame_unref(l_frame);
-		av_frame_unref(l_decoded_frame);
-	}
-
-	// Audio creation
-	l_audio->set_format(l_audio->FORMAT_16_BITS);
-	l_audio->set_mix_rate(l_codec_ctx_audio->sample_rate);
-	l_audio->set_stereo(l_stereo);
-	l_audio->set_data(l_audio_data);
-
-	// Cleanup
-	avcodec_flush_buffers(l_codec_ctx_audio);
-	avcodec_free_context(&l_codec_ctx_audio);
-	swr_free(&l_swr_ctx);
-
-	av_frame_free(&l_frame);
-	av_frame_free(&l_decoded_frame);
-	av_packet_free(&l_packet);
-
-	return l_audio;
+	return buffer_data->offset;
 }

--- a/src/ffmpeg.hpp
+++ b/src/ffmpeg.hpp
@@ -7,6 +7,7 @@ extern "C" {
 	#include <libavcodec/packet.h>
 	
 	#include <libavformat/avformat.h>
+	#include "libavformat/avio.h"
 	
 	#include <libavutil/avassert.h>
 	#include <libavutil/avutil.h>
@@ -31,6 +32,8 @@ extern "C" {
 #include <godot_cpp/classes/audio_stream_wav.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
+#include "ffmpeg_helpers.hpp"
+
 
 using namespace godot;
 
@@ -46,5 +49,6 @@ public:
 	static int get_frame(AVFormatContext *a_format_ctx, AVCodecContext *a_codec_ctx, int a_stream_id, AVFrame *a_frame, AVPacket *a_packet);
 	static enum AVPixelFormat get_hw_format(const enum AVPixelFormat *a_pix_fmt, enum AVPixelFormat *a_hw_pix_fmt);
 
-	static AudioStreamWAV *get_audio(AVFormatContext *a_format_ctx, AVStream *a_stream);
+	static int read_buffer_packet(void *opaque, uint8_t *buffer, int buffer_size);
+	static int64_t seek_buffer(void *opaque, int64_t offset, int where);
 };

--- a/src/ffmpeg_helpers.hpp
+++ b/src/ffmpeg_helpers.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 extern "C" {
@@ -11,7 +12,7 @@ extern "C" {
 }
 
 
-// AV Format Context helpers
+// AV Format Context helpers.
 struct AVFormatCtxInputDeleter {
 	void operator()(AVFormatContext* ctx) const {
 		if (ctx)
@@ -34,7 +35,7 @@ struct AVFormatCtxOutputDeleter {
 using UniqueAVFormatCtxOutput = std::unique_ptr<AVFormatContext, AVFormatCtxOutputDeleter>;
 
 
-// AV Codec Context helpers
+// AV Codec Context helpers.
 struct AVCodecCtxDeleter {
 	void operator()(AVCodecContext* ctx) const {
 		if (ctx) {
@@ -45,7 +46,7 @@ struct AVCodecCtxDeleter {
 using UniqueAVCodecCtx = std::unique_ptr<AVCodecContext, AVCodecCtxDeleter>;
 
 
-// AV Frame helper
+// AV Frame helper.
 struct AVFrameDeleter {
 	void operator()(AVFrame* frame) const {
 		if (frame) {
@@ -56,7 +57,7 @@ struct AVFrameDeleter {
 using UniqueAVFrame = std::unique_ptr<AVFrame, AVFrameDeleter>;
 
 
-// AV Packet helper
+// AV Packet helper.
 struct AVPacketDeleter {
 	void operator()(AVPacket* packet) const {
 		if (packet) {
@@ -67,7 +68,7 @@ struct AVPacketDeleter {
 using UniqueAVPacket = std::unique_ptr<AVPacket, AVPacketDeleter>;
 
 
-// SWResample Context helper
+// SWResample Context helper.
 struct SwrCtxDeleter {
 	void operator()(SwrContext* ctx) const {
 		if (ctx) {
@@ -78,7 +79,7 @@ struct SwrCtxDeleter {
 using UniqueSwrCtx = std::unique_ptr<SwrContext, SwrCtxDeleter>;
 
 
-// SWScale Context helper
+// SWScale Context helper.
 struct SwsCtxDeleter {
 	void operator()(SwsContext* ctx) const {
 		if (ctx) {
@@ -103,4 +104,11 @@ inline UniqueAVFrame make_unique_avframe() {
 inline UniqueAVPacket make_unique_avpacket() {
 	return make_unique_ffmpeg<AVPacket, AVPacketDeleter>(av_packet_alloc());
 }
+
+// For `res://` videos.
+struct BufferData {
+	uint8_t *ptr;
+	size_t size;
+	size_t offset;
+};
 

--- a/src/gozen_audio.hpp
+++ b/src/gozen_audio.hpp
@@ -6,6 +6,7 @@
 #include <godot_cpp/classes/control.hpp>
 #include <godot_cpp/classes/image_texture.hpp>
 #include <godot_cpp/classes/rendering_server.hpp>
+#include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 #include <godot_cpp/variant/packed_byte_array.hpp>
 #include <godot_cpp/core/math.hpp>

--- a/src/gozen_video.hpp
+++ b/src/gozen_video.hpp
@@ -9,11 +9,14 @@
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/image_texture.hpp>
 #include <godot_cpp/classes/gd_extension_manager.hpp>
-#include <godot_cpp/variant/utility_functions.hpp>
 #include <godot_cpp/classes/rendering_server.hpp>
+#include "godot_cpp/classes/file_access.hpp"
+#include <godot_cpp/variant/utility_functions.hpp>
+#include "godot_cpp/variant/packed_byte_array.hpp"
 
 #include "ffmpeg.hpp"
 #include "ffmpeg_helpers.hpp"
+#include "libavformat/avio.h"
 
 
 using namespace godot;
@@ -24,7 +27,8 @@ class GoZenVideo : public Resource {
 private:
 	// FFmpeg classes.
 	UniqueAVFormatCtxInput av_format_ctx;
-	UniqueAVCodecCtx av_codec_ctx = nullptr;
+	UniqueAVCodecCtx av_codec_ctx;
+	UniqueAVIOContext avio_ctx;
 	AVStream *av_stream = nullptr;
 
 	UniqueAVPacket av_packet;
@@ -33,6 +37,8 @@ private:
 	UniqueSwsCtx sws_ctx;
 
 	enum AVColorPrimaries color_profile;
+
+	BufferData buffer_data;
 
 	// Default variable types.
 	int response = 0;
@@ -70,6 +76,8 @@ private:
 	Ref<Image> u_data;
 	Ref<Image> v_data;
 
+	PackedByteArray file_buffer; // For `res://` videos.
+
 	// Private functions.
 	void _copy_frame_data();
 	void _clean_frame_data();
@@ -91,6 +99,7 @@ public:
 
 	static Dictionary get_file_meta(String file_path);
 
+	// For `res://` videos.
 	int open(const String& video_path);
 	void close();
 

--- a/test_room/addons/gde_gozen/README.md
+++ b/test_room/addons/gde_gozen/README.md
@@ -2,14 +2,9 @@
 ## Adding the addon to your project
 The GDE GoZen addon is very straightforward, put this folder `gde_gozen` inside of a folder called addons inside of your Godot project. You may need to restart you project as the GDExtension which interacts with FFmpeg will probably complain about something not being fully loaded. After reloading you will have access to a new node called `VideoPlayback`. This node has a lot of documentation comments so if you press F1 inside of Godot and search for the node `VideoPlayback`, you'll find it's documentation and more notes on how to use it.
 
+Since version 8.0 it's possible to add and play videos from your project directly. What you would need to adjust however is to add `mp4` and any other video extensions you might use to your Editor settings in `docks/filesystem/other_file_extensions` so they show up in your file explorer.
+
 ## Exporting your project
-When exporting your project, you will need to be careful of the way that you add your video files to your project. They can not be inside of your executable file and have to be added separately in a folder inside of your exported projects. Then inside of your code you can check if the project is run from the editor or not with: `OS.has_feature(“editor”)`.
-
-To get the path of your running project to find the folder where your video's are stored you can use `OS.get_executable_path()`. So it requires a bit of code to get things properly working, but everything should work without issues this way.
-
-We do globalize the path so if the structure is the same as in your `res://` folder, than there shouldn't be an issue.
-
-### FFmpeg libraries
 When exporting your projects, take in mind to bundle your executables with the FFmpeg library files which should be present in your exported projects folder.
 
 ## Help needed?

--- a/test_room/addons/gde_gozen/video_playback.gd
+++ b/test_room/addons/gde_gozen/video_playback.gd
@@ -110,11 +110,10 @@ func set_video_path(new_path: String) -> void:
 	path = new_path
 	if path == "":
 		return
-	elif path.begins_with("res://") or path.begins_with("user://"):
-		print("Path's with 'res://' don't work, globalizing path '%s' ...", % path)
+	elif not path.begins_with("res://") or not path.begins_with("user://"):
 		path = ProjectSettings.globalize_path(new_path)
-		print("New path: ", path)
-
+	else:
+		path = new_path
 
 	video = GoZenVideo.new()
 	if debug:

--- a/test_room/addons/gde_gozen/video_playback.gd
+++ b/test_room/addons/gde_gozen/video_playback.gd
@@ -3,10 +3,6 @@ extends Control
 ## Video playback and seeking inside of Godot.
 ##
 ## To use this node, just add it anywhere and resize it to the desired size. Use the function [code]set_video_path(new_path)[/code] and the video will load. Take in mind that long video's can take a second or longer to load. If this is an issue you can preload the Video on startup of your project and set the video variable yourself, just remember to use the function [code]update_video()[/code] before the moment that you'd like to use it.
-## [br][br]
-## There is a small limitation right now as FFmpeg requires a path to the video file so you can't make the video's part of the exported project and the [code]res://[/code] paths also don't work. This is just the nature of the beast and not something I can easily solve, but luckily there are solutions! First of all, the video path should be the full path, for testing this is easy as you can make the path whatever you want it to be, for exported projects ... Well, chances of the path being in the exact same location as on your pc are quite low.
-## [br][br]
-## The solution for exported projects is to create a folder inside of your exported projects in which you keep the video files, inside of your code you can check if the project is run from the editor or not with: [code]OS.has_feature(“editor”)[/code]. To get the path of your running project to find the folder where your video's are stored you can use [code]OS.get_executable_path()[/code]. So it requires a bit of code to get things properly working but everything should work without issues this way.
 
 
 signal frame_changed(frame_nr: int) ## Emitted when the current frame has changed, for showing and skipped frames.
@@ -24,7 +20,7 @@ const PLAYBACK_SPEED_MIN: float = 0.25
 const PLAYBACK_SPEED_MAX: float = 4
 
 
-@export_file var path: String = "": set = set_video_path ## Full path to video file. Do not use [code]res://[/code] paths, only provide [b]full[/b] paths. Solutions for setting the path in both editor and exported projects can be found in the readme info or on top.
+@export_file var path: String = "": set = set_video_path ## Full path to video file.
 @export var enable_audio: bool = true ## Enable/Disable audio playback. When setting this on false before loading the audio, the audio playback won't be loaded meaning that the video will load faster. If you want audio but only disable it at certain moments, switch this value to false *after* the video is loaded.
 @export var enable_auto_play: bool = false ## Enable/disable auto video playback.
 @export_range(PLAYBACK_SPEED_MIN, PLAYBACK_SPEED_MAX, 0.05)


### PR DESCRIPTION
Loading videos directly from the `res://` folder is the most important feature which has been left out of GDE GoZen. Time to change this for the next major version of GDE GoZen.

TODO:
- [ ] Custom AVIO file load option;
- [ ] Load videos and have playback from `res://` folder;
- [ ] Load audio and have playback from `res://` folder;
- [ ] Update the documentation (how enable adding mp4 files to export, ...);

Solves: #51 