### PR TITLE
Add audio/video syncing

### DIFF
--- a/test_room/addons/gde_gozen/video_playback.gd
+++ b/test_room/addons/gde_gozen/video_playback.gd
@@ -335,9 +335,9 @@ func pause() -> void:
 
 
 ## Ensures the audio playback is in sync with the video
-func _sync_audio_video():
+func _sync_audio_video() -> void:
 	if enable_audio and audio_player.stream.get_length() != 0:
-		var audio_offset = audio_player.get_playback_position() + AudioServer.get_time_since_last_mix() - (current_frame + 1) / _frame_rate
+		var audio_offset: float = audio_player.get_playback_position() + AudioServer.get_time_since_last_mix() - (current_frame + 1) / _frame_rate
 
 		if abs(audio_player.get_playback_position() + AudioServer.get_time_since_last_mix() - (current_frame + 1) / _frame_rate) > AUDIO_OFFSET_THRESHOLD:
 			if debug: print("Audio Sync: time correction: ", audio_offset)


### PR DESCRIPTION
Sometimes the video randomly stutters for just a tiny moment which results in out of sync audio.  
Also happens if the video is buffering when streaming from the network.

This ensures the audio is kept in sync with the video with an optional feature to slightly modify the audio playback speed when out of sync to prevent a hard cut if the audio is only slightly out of sync. **Note that the change in pitch is sometimes very slightly hearable.** I can remove that if it is not desired.

Also let me know if I should remove the prints.