### PR TITLE
Expose chapters to Godot

### DIFF
--- a/src/gozen_video.hpp
+++ b/src/gozen_video.hpp
@@ -115,6 +115,11 @@ class GoZenVideo : public Resource {
 	PackedInt32Array get_streams(int stream_type);
 	Dictionary get_stream_metadata(int stream_index);
 
+	int get_chapter_count();
+	float get_chapter_start(int chapter_index);
+	float get_chapter_end(int chapter_index);
+	Dictionary get_chapter_metadata(int chapter_index);
+
 	inline void set_sws_flag_bilinear() { sws_flag = SWS_BILINEAR; }
 	inline void set_sws_flag_bicubic() { sws_flag = SWS_BICUBIC; }
 


### PR DESCRIPTION
Makes video chapters accessible from Godot.
I did make duration_to_formatted_string public as I think it could be useful to some if they want display the duration of the video.

From the way I implemented it I don't think it should collide with your work on alpha channel support.
But if it does, feel free to let this sit until you're done with that. Chapter support is not really important anyway.