### PR TITLE
Implemented mbedtls for SSL communication

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -8,7 +8,10 @@ LIBS_COMMON = [
     "avcodec",
     "swscale",
     "swresample",
-    "avutil"]
+    "avutil",
+    "mbedtls",
+    "mbedx509",
+    "mbedcrypto"]
 LOCATION = "test_room/addons/gde_gozen/bin"
 
 march_flags = {

--- a/build.py
+++ b/build.py
@@ -45,7 +45,7 @@ ANDROID_API_LEVEL: int = 24
 
 ENABLED_MODULES = [
     "--enable-swscale",
-
+    "--enable-mbedtls",
     "--enable-demuxer=ogg",
     "--enable-demuxer=matroska,webm",
 ]
@@ -145,12 +145,14 @@ def compile_ffmpeg_linux(arch: str, add_av1: bool = False) -> None:
         "--disable-shared",
         "--enable-static",
         "--enable-pic",
+        "--enable-version3",
         "--disable-asm",
         f"--arch={arch}",
         "--target-os=linux",
         "--quiet",
         "--enable-pthreads",
         "--extra-cflags=-fPIC",
+        "--extra-libs=-lmbedtls -lmbedx509 -lmbedcrypto",
         # TODO: Remove this line if safe "--extra-ldflags=-fPIC",
     ]
     cmd += ENABLED_MODULES
@@ -189,6 +191,7 @@ def compile_ffmpeg_windows(arch: str, add_av1: bool = False) -> None:
         "--disable-shared",
         "--enable-static",
         "--enable-pic",
+	"--enable-version3",
         "--disable-asm",
         f"--arch={arch}",
         "--target-os=mingw32",
@@ -229,6 +232,7 @@ def compile_ffmpeg_macos(arch: str, add_av1: bool = False) -> None:
         "--disable-shared",
         "--enable-static",
         "--enable-pic",
+	"--enable-version3",
         "--disable-asm",
         f"--arch={arch}",
         "--quiet",
@@ -297,6 +301,7 @@ def compile_ffmpeg_android(arch: str) -> None:
         "--enable-static",
         "--disable-asm",
         "--enable-pic",
+	"--enable-version3",
         f"--arch={ffmpeg_arch}",
         "--target-os=android",
         "--enable-pic",
@@ -386,9 +391,11 @@ def compile_ffmpeg_web() -> None:
         "--extra-cflags=-O3 -msimd128 -DNDEBUG -pthread -sUSE_PTHREADS=1 -sASYNCIFY=1 -fPIC",
         "--extra-ldflags=-O3 -msimd128 -pthread -sUSE_PTHREADS=1 -sALLOW_MEMORY_GROWTH=1 -sASYNCIFY=1 -fPIC -sWASM_BIGINT=1",
         "--enable-pic",
+		"--enable-version3",
         "--enable-small",
         "--disable-everything",
 
+		"--enable-mbedtls",
         "--enable-avcodec",
         "--enable-avformat",
         "--enable-avutil",


### PR DESCRIPTION
MbedTLS is a small library (around 800kb) which provides ability to create SSL connections.  This updates the build.py script to use mbedtls library, and statically link it into a single dll/so/dynlib file.  It also updates SConstruct to add dependencies for mbedtls, mbedx509 and mbedcrypto to the static build.